### PR TITLE
Bugfix

### DIFF
--- a/src/Presentation/DiagramApp.Client/ViewModels/MainViewModel.cs
+++ b/src/Presentation/DiagramApp.Client/ViewModels/MainViewModel.cs
@@ -100,7 +100,8 @@ namespace DiagramApp.Client.ViewModels
         [RelayCommand]
         private void ResetItemInCanvas()
         {
-            CurrentCanvas!.DeselectFigure();
+            if (CurrentCanvas is not null && CurrentCanvas.SelectedFigure is not null)
+                CurrentCanvas!.DeselectFigure();
         }
 
         [RelayCommand]


### PR DESCRIPTION
1. Empty click on canvas throws exception by resetting selected item